### PR TITLE
Use the package installation script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM vcatechnology/linux-mint-ci:18
+FROM vcatechnology/linux-mint-ci
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 # Install useful packages
-RUN sudo apt-get install -y \
+RUN sudo vca-install-package \
   python-pip \
   g++ \
   libtool \


### PR DESCRIPTION
Performs an optimal installation of packages keeping the image size as small as possible

Requires [vcatechnology/docker-linux-mint!1](https://github.com/vcatechnology/docker-linux-mint/pull/1)